### PR TITLE
fix (gaps): use nulls to indicate missing rides

### DIFF
--- a/src/api/gapsService.ts
+++ b/src/api/gapsService.ts
@@ -12,10 +12,10 @@ type RawGapsList = {
   }[]
 }
 
-const parseTime = (day: Moment, time: string): Moment | undefined =>
-  time === 'None' ? undefined : moment(day).add(moment.duration(time))
+const parseTime = (day: Moment, time: string): Moment | null =>
+  day && time && time !== 'None' ? moment(day).add(moment.duration(time)) : null
 
-const USE_API = false
+const USE_API = true
 
 export const getGapsAsync = async (
   timestamp: Moment,
@@ -27,9 +27,9 @@ export const getGapsAsync = async (
   const data = USE_API
     ? (
         await axios.get<RawGapsList>(
-          `https://evyatar.pythonanywhere.com/siri3/${startOfDay.format(
+          `http://ec2-52-201-152-176.compute-1.amazonaws.com/get_rides_statistics/${lineRef}/${operatorId}/${startOfDay.format(
             'YYYY-MM-DD',
-          )}/${lineRef}/${operatorId}`,
+          )}`,
         )
       ).data
     : EXAMPLE_DATA

--- a/src/model/gaps.ts
+++ b/src/model/gaps.ts
@@ -1,6 +1,6 @@
 import moment from 'moment'
 
 export type GapsList = {
-  siriTime: moment.Moment | undefined
-  gtfsTime: moment.Moment | undefined
+  siriTime: moment.Moment | null
+  gtfsTime: moment.Moment | null
 }[]

--- a/src/pages/GapsPage.tsx
+++ b/src/pages/GapsPage.tsx
@@ -16,7 +16,7 @@ import { getRoutesAsync } from '../api/gtfsService'
 import { Moment } from 'moment'
 import styled from 'styled-components'
 
-function formatTime(time: Moment | undefined) {
+function formatTime(time: Moment | null) {
   return time ? time.format(TEXTS.time_format) : TEXTS.ride_missing
 }
 


### PR DESCRIPTION
# changes:
1. fix: when the backend returns `null`, the time was parsed as midnight. now it's still nullish
2. fix: new server URL